### PR TITLE
Fix/console errors

### DIFF
--- a/checkout_with_abandoned_onlineclass.js
+++ b/checkout_with_abandoned_onlineclass.js
@@ -2686,7 +2686,7 @@ class CheckOutWebflow extends BriefsUpsellModal {
 		let variant = 1;
 		//let topicPripUpSellModal = document.querySelector('.topic-prep_modal-container')
 		let tutoringUpSellModal = document.querySelector('.upsell-modal-container.tutoring')
-		if (window.getComputedStyle(tutoringUpSellModal).display != 'none') {
+		if (tutoringUpSellModal && window.getComputedStyle(tutoringUpSellModal).display != 'none') {
 			variant = 2;
 		}
 		return variant

--- a/checkout_with_abandoned_onlineclass.js
+++ b/checkout_with_abandoned_onlineclass.js
@@ -1005,6 +1005,9 @@ class CheckOutWebflow extends BriefsUpsellModal {
 					if (checkbox.checked) {
 						checkbox.checked = !checkbox.checked
 						this.updateAmount(checkbox, checkbox.value);
+						if(checkbox.closest('.you-might_slide-item')){
+							checkbox.closest('.you-might_slide-item').classList.toggle('border-red')
+						}	
 					}
 
 					// Find the corresponding "add-to-card" button inside the same parent div
@@ -2357,6 +2360,10 @@ class CheckOutWebflow extends BriefsUpsellModal {
 						}
 						// Optional: Add or remove a disabled class (if needed)
 						button.classList.toggle("disabled", checkbox.checked);
+						// Add red border in slider 
+						if(button.closest('.you-might_slide-item')){
+							button.closest('.you-might_slide-item').classList.toggle('border-red')
+						}
 						// update added text for same program in another section
 						var programDetailId = checkbox.getAttribute('programdetailid');
 						var elementSelector = ".supp_program_"+programDetailId;;
@@ -2395,6 +2402,18 @@ class CheckOutWebflow extends BriefsUpsellModal {
 		});
 	}
 	async displaySupplementaryProgram() {
+		let container2 = document.getElementById("checkout-supplimentary-data-2");
+		let swiperSlideWrapper = container2.querySelector('.you-might_slick-slider')
+
+		
+		// New Slider with add-to-cart and learn more button
+		let container3 = document.getElementById("checkout-supplimentary-data-desktop");
+		let newSlideWrapper = container3.querySelector('.you-might-slider-container')
+
+		// For Mobile Slider
+		let container4 = document.getElementById("checkout-supplimentary-data-mobile");
+		let mobileSlideWrapper = container4.querySelector('.you-might-slider-container-mobile')
+
 		if (this.$suppPro.length > 0) return;
 		// getSupplementaryProgram API call removed; use empty data so supplementary UI still runs
 		let apiData = [];
@@ -2423,6 +2442,33 @@ class CheckOutWebflow extends BriefsUpsellModal {
 		}
 		apiData = apiData.filter(i => i.programDetailId != 21);
 
+		if(!apiData.length){
+			swiperSlideWrapper.style.display="none";
+			// New Slider hide if no API data
+			newSlideWrapper.style.display = "none";
+
+			mobileSlideWrapper.style.display = "none";
+			
+		}
+		
+		if (container2 == undefined) return;
+
+		if(container3 == undefined) return;
+		if(container4 == undefined) return;
+		
+		if (swiperSlideWrapper == undefined) return
+
+		if (newSlideWrapper == undefined) return
+
+		if (mobileSlideWrapper == undefined) return
+
+		// Modal Content Update
+		
+
+		swiperSlideWrapper.innerHTML = "";
+		newSlideWrapper.innerHTML = "";
+		mobileSlideWrapper.innerHTML = "";
+
 		// Modal Content Update
 		let modalContent = document.querySelector(
 			".supp-programs-description-wrapper"
@@ -2439,6 +2485,24 @@ class CheckOutWebflow extends BriefsUpsellModal {
 
 		apiData.forEach(item => {
 			item.forumType = "Public Forum";
+			//slider div
+			let swiperSlide = creEl('div', 'you-might_slide-item')
+			const outerShadowDiv1 = this.displaySingleSuppProgram(item, 'desktop', swiperSlide);
+			swiperSlide.appendChild(outerShadowDiv1)
+			swiperSlideWrapper.prepend(swiperSlide)
+
+			//newSlider div
+			let newSliderSlide = creEl('div', 'you-might_slide-item')
+			const newOuterShadowDiv1 = this.newDisplaySingleSuppProgram(item, 'desktop', newSliderSlide);
+			newSliderSlide.appendChild(newOuterShadowDiv1)
+			newSlideWrapper.prepend(newSliderSlide)
+
+			//Mobile slider div
+			let mobileSliderSlide = creEl('div', 'you-might_slide-item')
+			const mobileOuterShadowDiv1 = this.newDisplaySingleSuppProgram(item, 'desktop', mobileSliderSlide);
+			mobileSliderSlide.appendChild(mobileOuterShadowDiv1)
+			mobileSlideWrapper.prepend(mobileSliderSlide)
+
 			// Modal Content Update
 			const modalSingleContent = this.displayModalSuppProgram(item, "modal");
 			modalContent.prepend(modalSingleContent);
@@ -2448,12 +2512,93 @@ class CheckOutWebflow extends BriefsUpsellModal {
 		// Setup back button for browser and stripe checkout page
 		this.setUpBackButtonTab();
 		if(apiData.length == 0){
+			container2.style.display = "none";
+			container3.style.display = "none";
+			container4.style.display = "none";
 			return;
 		}
 	}
 	initSlickSlider() {
-	}
+		var $slider = $('.you-might_slick-slider');
+		
+		if ($slider.hasClass('slick-initialized')) {
+			$slider.slick('destroy');
+			$slider.slick('unslick'); // Destroy slick instance
+		}
+		var slickSettings = {
+			speed: 300,
+			slidesToShow: 1,
+			slidesToScroll: 1,
+			infinite: false,
+			centerMode: false,
+			variableWidth: false,
+			arrows: false,
+			dots: true,
+			adaptiveHeight: true
+		};
+		// Check if the slider is already initialized
+		if (!$slider.hasClass('slick-initialized')) {
+			// Initialize you might slider
+			var $sliderYouMight = $slider.slick(slickSettings);
 
+			// Shared navigation logic for the "You Might" slider
+			$('.left-arrow-slick').click(function () {
+				//console.log("You Might: Left arrow clicked.");
+				$sliderYouMight.slick('slickPrev');
+			});
+
+			$('.right-arrow-slick').click(function () {
+				//console.log("You Might: Right arrow clicked.");
+				$sliderYouMight.slick('slickNext');
+			});
+		}
+		// New Slider
+		var $slider2 = $('.you-might-slider-container');
+		
+		if ($slider2.hasClass('slick-initialized')) {
+			$slider2.slick('destroy');
+			$slider2.slick('unslick'); // Destroy slick instance
+		}
+		// Check if the slider is already initialized
+		if (!$slider2.hasClass('slick-initialized')) {
+			// Initialize you might slider
+			var $sliderYouMightNew = $slider2.slick(slickSettings);
+
+			$('.you-might-left-arrow').click(function () {
+				//console.log("You Might: Left arrow clicked.");
+				$sliderYouMightNew.slick('slickPrev');
+			});
+	 
+			$('.you-might-right-arrow').click(function () {
+				//console.log("You Might: Right arrow clicked.");
+				$sliderYouMightNew.slick('slickNext');
+			});
+		}
+
+		// Mobile Slider
+		var $slider3 = $('.you-might-slider-container-mobile');
+		
+		if ($slider3.hasClass('slick-initialized')) {
+			$slider3.slick('destroy');
+			$slider3.slick('unslick'); // Destroy slick instance
+		}
+		// Check if the slider is already initialized
+		if (!$slider3.hasClass('slick-initialized')) {
+			// Initialize you might slider
+			var $sliderYouMightMobile = $slider3.slick(slickSettings);
+
+			$('.you-might-left-arrow').click(function () {
+				//console.log("You Might: Left arrow clicked.");
+				$sliderYouMightMobile.slick('slickPrev');
+			});
+	 
+			$('.you-might-right-arrow').click(function () {
+				//console.log("You Might: Right arrow clicked.");
+				$sliderYouMightMobile.slick('slickNext');
+			});
+		}
+
+	}
 	updateUpSellModal(prep_week_data, tutoring_data, care_package_data) {
 
 		if (prep_week_data.length > 0) {
@@ -2813,7 +2958,7 @@ class CheckOutWebflow extends BriefsUpsellModal {
 	newDisplaySingleSuppProgram(item, size, slideDiv) {
 		// Create main grid container
 		const gridDiv = document.createElement("div");
-		gridDiv.classList.add("w-layout-grid", "payment-conf-program-grid");
+		gridDiv.classList.add("w-layout-grid", "payment-conf-program-grid", "you-might");
 	  
 		// Left column container
 		const leftCol = document.createElement("div");
@@ -2886,12 +3031,12 @@ class CheckOutWebflow extends BriefsUpsellModal {
 	  
 		// Right column buttons
 		const buttonDiv = document.createElement("div");
-		buttonDiv.classList.add("button-div");
+		buttonDiv.classList.add("button-div", "you-might-buttons-wrapper");
 	  
 		const addToCartBtn = document.createElement("a");
 		addToCartBtn.href = "#";
 		let programClass = "supp_program_"+item.programDetailId;
-		addToCartBtn.classList.add("main-button", "red", "add-to-card", "w-button", programClass);
+		addToCartBtn.classList.add("main-button", "red", "add-to-card", "you-might-add-to-cart", "w-button", programClass);
 		addToCartBtn.textContent = "Add to Cart";
 		const learnMoreBtn = document.createElement("a");
 		if(item.benefits.length > 0){


### PR DESCRIPTION
# Fix: Guard getComputedStyle call when tutoring upsell modal is missing

## Problem
Console error when the tutoring upsell modal isn't in the DOM:

```
Uncaught (in promise) TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
```

This occurred in `getVariant()` when calling `window.getComputedStyle(tutoringUpSellModal)` after `document.querySelector('.upsell-modal-container.tutoring')` returned `null`.

## Solution
Add a null check before calling `getComputedStyle` so it's only invoked when the element exists:

```javascript
if (tutoringUpSellModal && window.getComputedStyle(tutoringUpSellModal).display != 'none') {
  variant = 2;
}
```

If the selector doesn't match any element, `tutoringUpSellModal` is falsy and we skip the call, avoiding the error and defaulting to `variant = 1`.