### PR TITLE
Fix/console errors

### DIFF
--- a/checkout_with_abandoned_onlineclass.js
+++ b/checkout_with_abandoned_onlineclass.js
@@ -2686,7 +2686,7 @@ class CheckOutWebflow extends BriefsUpsellModal {
 		let variant = 1;
 		//let topicPripUpSellModal = document.querySelector('.topic-prep_modal-container')
 		let tutoringUpSellModal = document.querySelector('.upsell-modal-container.tutoring')
-		if (window.getComputedStyle(tutoringUpSellModal).display != 'none') {
+		if (tutoringUpSellModal && window.getComputedStyle(tutoringUpSellModal).display != 'none') {
 			variant = 2;
 		}
 		return variant

--- a/checkout_with_abandoned_onlineclass.js
+++ b/checkout_with_abandoned_onlineclass.js
@@ -2428,8 +2428,8 @@ class CheckOutWebflow extends BriefsUpsellModal {
 			".supp-programs-description-wrapper"
 		  );
 	  
-		if (!apiData.length) {
-		modalContent.style.display = "none";
+		if (modalContent && !apiData.length) {
+			modalContent.style.display = "none";
 		}
 	
 		if (modalContent == undefined) return;


### PR DESCRIPTION
# Fix: Guard getComputedStyle call when tutoring upsell modal is missing

## Problem
Console error when the tutoring upsell modal isn't in the DOM:

```
Uncaught (in promise) TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
```

This occurred in `getVariant()` when calling `window.getComputedStyle(tutoringUpSellModal)` after `document.querySelector('.upsell-modal-container.tutoring')` returned `null`.

## Solution
Add a null check before calling `getComputedStyle` so it's only invoked when the element exists:

```javascript
if (tutoringUpSellModal && window.getComputedStyle(tutoringUpSellModal).display != 'none') {
  variant = 2;
}
```

If the selector doesn't match any element, `tutoringUpSellModal` is falsy and we skip the call, avoiding the error and defaulting to `variant = 1`.