### PR TITLE
Show pre‑camp only for enrolled camp students

### DIFF
--- a/new_portal.js
+++ b/new_portal.js
@@ -195,7 +195,7 @@ class NSDPortal {
         });
 
         // Hide pre-camp Webflow component when user is enrolled (has camp/student data)
-        const preCampElement = document.getElementById("hide_pre_camp");
+        const preCampElement = document.getElementByClassName("hide_pre_camp");
         if (preCampElement) {
             preCampElement.style.display = hasStudentData ? "none" : "block";
         }

--- a/new_portal.js
+++ b/new_portal.js
@@ -195,7 +195,7 @@ class NSDPortal {
         });
 
         // Hide pre-camp Webflow component when user is enrolled (has camp/student data)
-        const preCampElement = document.getElementByClassName("hide_pre_camp");
+        const preCampElement = document.querySelector(".hide_pre_camp");
         if (preCampElement) {
             preCampElement.style.display = hasStudentData ? "none" : "block";
         }

--- a/new_portal.js
+++ b/new_portal.js
@@ -194,10 +194,10 @@ class NSDPortal {
             tab.style.display = hasStudentData ? "flex" : "none";
         });
 
-        // Hide pre-camp Webflow component when user is enrolled (has camp/student data)
+        // Show pre-camp Webflow component ONLY when student is enrolled in camp
         const preCampElement = document.querySelector(".hide_pre_camp");
         if (preCampElement) {
-            preCampElement.style.display = hasStudentData ? "none" : "block";
+            preCampElement.style.display = hasStudentData ? "block" : "none";
         }
  
 

--- a/new_portal.js
+++ b/new_portal.js
@@ -248,12 +248,6 @@ class NSDPortal {
 
     // Hide online-class tab and its pane when enrollments are empty; show when enrollments exist
     setOnlineClassTabVisibility(hasEnrollments) {
-       
-        const preCampElement = document.getElementById("hide_pre_camp");
-        if (preCampElement) {
-            preCampElement.style.display = hasStudentData ? "none" : "block";
-        }
-        
         const tab = document.querySelector('[data-portal="online-class-tab"]');
         if (!tab) return;
         const paneId = tab.getAttribute('aria-controls') || (tab.getAttribute('href') || '').replace('#', '');
@@ -262,27 +256,52 @@ class NSDPortal {
         tab.style.display = displayVal;
         if (pane) pane.style.display = displayVal;
 
-        // When Classes tab is visible, make it the active tab so Tab 1 isn't left active
-        if (hasEnrollments) {
-            const tabList = tab.closest('[role="tablist"]') || tab.parentElement;
-            const tabContent = tab.closest('.w-tabs')?.querySelector('.w-tab-content') || pane?.parentElement;
-            if (tabList) {
-                tabList.querySelectorAll('[role="tab"], .w-tab-link').forEach(link => {
-                    link.classList.remove('w--tab-active', 'w--current');
-                    link.setAttribute('aria-selected', 'false');
-                    link.setAttribute('tabindex', '-1');
-                });
-                tab.classList.add('w--tab-active', 'w--current');
-                tab.setAttribute('aria-selected', 'true');
-                tab.setAttribute('tabindex', '0');
+        // After toggling visibility, ensure the first visible tab in this group is active
+        const tabsRoot = tab.closest('.w-tabs') || document;
+        this.setFirstVisibleTabActive(tabsRoot);
+    }
+
+    // Ensure the first visible tab in each Webflow tabs component is selected by default
+    setFirstVisibleTabActive(rootElement) {
+        const scope = rootElement || document;
+        const tabContainers = scope.querySelectorAll('.w-tabs');
+
+        tabContainers.forEach(container => {
+            const tabMenu = container.querySelector('.w-tab-menu');
+            const tabContent = container.querySelector('.w-tab-content');
+            if (!tabMenu || !tabContent) return;
+
+            const tabLinks = Array.from(tabMenu.querySelectorAll('[role="tab"], .w-tab-link'));
+            if (!tabLinks.length) return;
+
+            // Find the first tab link that is actually visible
+            const firstVisibleTab = tabLinks.find(link => link.offsetParent !== null);
+            if (!firstVisibleTab) return;
+
+            // Reset all tabs
+            tabLinks.forEach(link => {
+                link.classList.remove('w--tab-active', 'w--current');
+                link.setAttribute('aria-selected', 'false');
+                link.setAttribute('tabindex', '-1');
+            });
+
+            // Activate the first visible tab
+            firstVisibleTab.classList.add('w--tab-active', 'w--current');
+            firstVisibleTab.setAttribute('aria-selected', 'true');
+            firstVisibleTab.setAttribute('tabindex', '0');
+
+            // Activate the corresponding pane
+            const paneId = firstVisibleTab.getAttribute('aria-controls') || (firstVisibleTab.getAttribute('href') || '').replace('#', '');
+            if (!paneId) return;
+
+            const panes = tabContent.querySelectorAll('.w-tab-pane, [role="tabpanel"]');
+            panes.forEach(p => p.classList.remove('w--tab-active'));
+
+            const activePane = tabContent.querySelector(`#${paneId}`);
+            if (activePane) {
+                activePane.classList.add('w--tab-active');
             }
-            if (tabContent) {
-                tabContent.querySelectorAll('.w-tab-pane, [role="tabpanel"]').forEach(p => {
-                    p.classList.remove('w--tab-active');
-                });
-                if (pane) pane.classList.add('w--tab-active');
-            }
-        }
+        });
     }
 
     // Render the main portal
@@ -351,6 +370,9 @@ class NSDPortal {
                 if (typeof Webflow !== 'undefined' && Webflow.require('tabs')) {
                     Webflow.require('tabs').redraw();
                 }
+
+                // Always ensure first visible tab is active after Webflow initializes
+                this.setFirstVisibleTabActive();
 
                 // Initialize nested program tabs for the first (active) student tab
                 this.initializeNestedProgramTabs(0);
@@ -458,6 +480,10 @@ class NSDPortal {
             try {
                 // Force Webflow to re-initialize the nested tabs
                 Webflow.require('tabs').redraw();
+
+                // Ensure first visible nested program tab is active
+                this.setFirstVisibleTabActive(nestedTabsContainer);
+
                 console.log(`Nested program tabs initialized for student index ${studentIndex}`);
             } catch (error) {
                 console.error('Error initializing nested program tabs:', error);

--- a/new_portal.js
+++ b/new_portal.js
@@ -194,6 +194,13 @@ class NSDPortal {
             tab.style.display = hasStudentData ? "flex" : "none";
         });
 
+        // Hide pre-camp Webflow component when user is enrolled (has camp/student data)
+        const preCampElement = document.getElementById("hide_pre_camp");
+        if (preCampElement) {
+            preCampElement.style.display = hasStudentData ? "none" : "block";
+        }
+ 
+
         // Handle briefs-tab visibility based on briefs data availability
         const briefsTabs = document.querySelectorAll('[data-portal="briefs-tab"]');
         const hasBriefsData = briefsData && Array.isArray(briefsData) && briefsData.length > 0;
@@ -241,6 +248,12 @@ class NSDPortal {
 
     // Hide online-class tab and its pane when enrollments are empty; show when enrollments exist
     setOnlineClassTabVisibility(hasEnrollments) {
+       
+        const preCampElement = document.getElementById("hide_pre_camp");
+        if (preCampElement) {
+            preCampElement.style.display = hasStudentData ? "none" : "block";
+        }
+        
         const tab = document.querySelector('[data-portal="online-class-tab"]');
         if (!tab) return;
         const paneId = tab.getAttribute('aria-controls') || (tab.getAttribute('href') || '').replace('#', '');

--- a/new_portal.js
+++ b/new_portal.js
@@ -304,6 +304,57 @@ class NSDPortal {
         });
     }
 
+    // Fallback activation for top-level portal tabs (camp/briefs/online-classes)
+    attachTopLevelTabFallbackHandlers() {
+        const topLevelTabs = document.querySelectorAll(
+            '[data-portal="camp-tab"], [data-portal="briefs-tab"], [data-portal="online-class-tab"]'
+        );
+
+        topLevelTabs.forEach(tab => {
+            if (tab.dataset.fallbackHandlerAttached === 'true') return;
+
+            tab.addEventListener('click', (e) => {
+                // Keep first click reliable if Webflow tab binding is late
+                e.preventDefault();
+                this.activateTabLink(tab);
+            });
+
+            tab.dataset.fallbackHandlerAttached = 'true';
+        });
+    }
+
+    // Generic tab activator for Webflow-style tab links
+    activateTabLink(tabLink) {
+        if (!tabLink) return;
+        const tabsRoot = tabLink.closest('.w-tabs');
+        if (!tabsRoot) return;
+
+        const tabMenu = tabsRoot.querySelector('.w-tab-menu');
+        const tabContent = tabsRoot.querySelector('.w-tab-content');
+        if (!tabMenu || !tabContent) return;
+
+        const tabLinks = Array.from(tabMenu.querySelectorAll('[role="tab"], .w-tab-link'));
+        tabLinks.forEach(link => {
+            link.classList.remove('w--tab-active', 'w--current');
+            link.setAttribute('aria-selected', 'false');
+            link.setAttribute('tabindex', '-1');
+        });
+
+        tabLink.classList.add('w--tab-active', 'w--current');
+        tabLink.setAttribute('aria-selected', 'true');
+        tabLink.setAttribute('tabindex', '0');
+
+        const paneId = tabLink.getAttribute('aria-controls') || (tabLink.getAttribute('href') || '').replace('#', '');
+        const panes = tabContent.querySelectorAll('.w-tab-pane, [role="tabpanel"]');
+        panes.forEach(pane => pane.classList.remove('w--tab-active'));
+
+        if (!paneId) return;
+        const activePane = tabContent.querySelector(`#${paneId}`) || document.getElementById(paneId);
+        if (activePane) {
+            activePane.classList.add('w--tab-active');
+        }
+    }
+
     // Render the main portal
     renderPortal() {
         const container = document.getElementById('nsdPortal');
@@ -388,6 +439,9 @@ class NSDPortal {
 
                 // Attach event handlers to invoice payment links
                 this.attachInvoicePaymentHandlers();
+
+                // Fallback for top-level tabs when Webflow handlers are delayed
+                this.attachTopLevelTabFallbackHandlers();
 
                 console.log('Webflow tabs initialized successfully');
             } catch (error) {


### PR DESCRIPTION
**Summary**

This PR updates new_portal.js in two areas:

Updates hidePortalData to control visibility of the Webflow pre-camp section based on whether a logged-in student has an existing camp enrollment.
Adds logic to ensure each Webflow tab group always defaults to the first visible tab, preventing hidden or unavailable tabs from remaining selected.


**Changes**



Pre-camp visibility

Reuses the existing hasStudentData flag (derived from the studentData API response) to determine if a student is logged in and has at least one camp enrollment.
Targets the Webflow pre-camp wrapper using the .hide_pre_camp selector.
Implements conditional visibility logic in hidePortalData:

If hasStudentData === true → .hide_pre_camp is displayed (display: "block").
If hasStudentData === false → .hide_pre_camp is hidden (display: "none").


**Default visible tab selection**

Added a helper setFirstVisibleTabActive in new_portal.js that, for each Webflow w-tabs group, finds the first visible tab and makes it active along with its corresponding pane.
Calls this helper after Webflow tabs are initialized in initializeWebflowTabs, so on page load every tab group has a clear default selection.
Calls this helper from setOnlineClassTabVisibility, so when the Classes tab is shown or hidden, the group’s first visible tab becomes active.
Calls this helper from initializeNestedProgramTabs, so each student’s nested program tabs also default to the first visible program tab.